### PR TITLE
fix: stable anchor for add block menu

### DIFF
--- a/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/index.tsx
+++ b/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { TEditorBlock } from '../../../../editor/core';
 
@@ -12,23 +12,33 @@ type Props = {
 };
 export default function AddBlockButton({ onSelect, placeholder }: Props) {
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
-  const [buttonElement, setButtonElement] = useState<HTMLElement | null>(null);
+  const buttonElementRef = useRef<HTMLElement | null>(null);
 
   const handleButtonClick = () => {
-    setMenuAnchorEl(buttonElement);
+    setMenuAnchorEl(buttonElementRef.current);
   };
 
   const renderButton = () => {
     if (placeholder) {
       return <PlaceholderButton onClick={handleButtonClick} />;
     } else {
-      return <DividerButton buttonElement={buttonElement} onClick={handleButtonClick} />;
+      return (
+        <DividerButton
+          buttonElement={buttonElementRef.current}
+          onClick={handleButtonClick}
+        />
+      );
     }
   };
 
   return (
     <>
-      <div ref={setButtonElement} style={{ position: 'relative' }}>
+      <div
+        ref={(el) => {
+          buttonElementRef.current = el;
+        }}
+        style={{ position: 'relative' }}
+      >
         {renderButton()}
       </div>
       <BlocksMenu anchorEl={menuAnchorEl} setAnchorEl={setMenuAnchorEl} onSelect={onSelect} />


### PR DESCRIPTION
## Summary
- ensure AddBlockButton uses ref to store menu anchor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*
- `npm run build:types` *(fails: No inputs were found in config file '/workspace/emailBuilder/tsconfig.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b0998cdb74832fac4e24f8ba83d21a