### PR TITLE
fix: anchor add block menu to clicked element

### DIFF
--- a/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/DividerButton.d.ts
+++ b/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/DividerButton.d.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 type Props = {
     buttonElement: HTMLElement | null;
-    onClick: () => void;
+    onClick: (ev: React.MouseEvent<HTMLElement>) => void;
 };
 export default function DividerButton({ buttonElement, onClick }: Props): React.JSX.Element;
 export {};

--- a/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/DividerButton.js
+++ b/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/DividerButton.js
@@ -41,7 +41,7 @@ export default function DividerButton({ buttonElement, onClick }) {
                 },
             }, onClick: (ev) => {
                 ev.stopPropagation();
-                onClick();
+                onClick(ev);
             } },
             React.createElement(AddOutlined, { fontSize: "small" }))));
 }

--- a/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/DividerButton.tsx
+++ b/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/DividerButton.tsx
@@ -5,7 +5,7 @@ import { Fade, IconButton } from '@mui/material';
 
 type Props = {
   buttonElement: HTMLElement | null;
-  onClick: () => void;
+  onClick: (ev: React.MouseEvent<HTMLElement>) => void;
 };
 export default function DividerButton({ buttonElement, onClick }: Props) {
   const [visible, setVisible] = useState(false);
@@ -54,7 +54,7 @@ export default function DividerButton({ buttonElement, onClick }: Props) {
         }}
         onClick={(ev) => {
           ev.stopPropagation();
-          onClick();
+          onClick(ev);
         }}
       >
         <AddOutlined fontSize="small" />

--- a/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/PlaceholderButton.d.ts
+++ b/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/PlaceholderButton.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 type Props = {
-    onClick: () => void;
+    onClick: (ev: React.MouseEvent<HTMLElement>) => void;
 };
 export default function PlaceholderButton({ onClick }: Props): React.JSX.Element;
 export {};

--- a/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/PlaceholderButton.js
+++ b/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/PlaceholderButton.js
@@ -4,7 +4,7 @@ import { ButtonBase } from '@mui/material';
 export default function PlaceholderButton({ onClick }) {
     return (React.createElement(ButtonBase, { onClick: (ev) => {
             ev.stopPropagation();
-            onClick();
+            onClick(ev);
         }, sx: {
             display: 'flex',
             alignContent: 'center',

--- a/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/PlaceholderButton.tsx
+++ b/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/PlaceholderButton.tsx
@@ -4,14 +4,14 @@ import { AddOutlined } from '@mui/icons-material';
 import { ButtonBase } from '@mui/material';
 
 type Props = {
-  onClick: () => void;
+  onClick: (ev: React.MouseEvent<HTMLElement>) => void;
 };
 export default function PlaceholderButton({ onClick }: Props) {
   return (
     <ButtonBase
       onClick={(ev) => {
         ev.stopPropagation();
-        onClick();
+        onClick(ev);
       }}
       sx={{
         display: 'flex',

--- a/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/index.js
+++ b/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/index.js
@@ -5,15 +5,15 @@ import PlaceholderButton from './PlaceholderButton';
 export default function AddBlockButton({ onSelect, placeholder }) {
     const [menuAnchorEl, setMenuAnchorEl] = useState(null);
     const [buttonElement, setButtonElement] = useState(null);
-    const handleButtonClick = () => {
-        setMenuAnchorEl(buttonElement);
+    const handleButtonClick = (ev) => {
+        setMenuAnchorEl(ev.currentTarget);
     };
     const renderButton = () => {
         if (placeholder) {
             return React.createElement(PlaceholderButton, { onClick: handleButtonClick });
         }
         else {
-            return React.createElement(DividerButton, { buttonElement: buttonElement, onClick: handleButtonClick });
+            return (React.createElement(DividerButton, { buttonElement: buttonElement, onClick: handleButtonClick }));
         }
     };
     return (React.createElement(React.Fragment, null,

--- a/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/index.tsx
+++ b/packages/editor-sample/src/documents/blocks/helpers/EditorChildrenIds/AddBlockMenu/index.tsx
@@ -14,15 +14,20 @@ export default function AddBlockButton({ onSelect, placeholder }: Props) {
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
   const [buttonElement, setButtonElement] = useState<HTMLElement | null>(null);
 
-  const handleButtonClick = () => {
-    setMenuAnchorEl(buttonElement);
+  const handleButtonClick = (ev: React.MouseEvent<HTMLElement>) => {
+    setMenuAnchorEl(ev.currentTarget);
   };
 
   const renderButton = () => {
     if (placeholder) {
       return <PlaceholderButton onClick={handleButtonClick} />;
     } else {
-      return <DividerButton buttonElement={buttonElement} onClick={handleButtonClick} />;
+      return (
+        <DividerButton
+          buttonElement={buttonElement}
+          onClick={handleButtonClick}
+        />
+      );
     }
   };
 
@@ -31,7 +36,11 @@ export default function AddBlockButton({ onSelect, placeholder }: Props) {
       <div ref={setButtonElement} style={{ position: 'relative' }}>
         {renderButton()}
       </div>
-      <BlocksMenu anchorEl={menuAnchorEl} setAnchorEl={setMenuAnchorEl} onSelect={onSelect} />
+      <BlocksMenu
+        anchorEl={menuAnchorEl}
+        setAnchorEl={setMenuAnchorEl}
+        onSelect={onSelect}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- anchor BlocksMenu to the element actually clicked
- forward click events through DividerButton and PlaceholderButton for reliable anchoring

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*
- `npm run build:types` *(fails: No inputs were found in config file '/workspace/emailBuilder/tsconfig.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b0998cdb74832fac4e24f8ba83d21a